### PR TITLE
bugfix/remove pins

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,11 +28,11 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-  "bioio-base>=0.3.0,<2.0.0",
+  "bioio-base>=0.3.0",
   "dask[array]>=2021.4.1",
   "fsspec>=2022.8.0",
   "imagecodecs>=2020.5.30",
-  "numpy>=1.16,<2",
+  "numpy>=1.16",
   "tifffile>=2022.4.22",
   "xarray>=0.16.1",
   "zarr>=2.6",


### PR DESCRIPTION
Noticed some weird pinning when looking over depreciated dependencies. Two things, 1) there was pin for bioio of a version we haven't released yet 2) numpy was pinned, I expect from our old support of python 3.8
