### PR TITLE
feature/ome-tiff-suggestion

### DIFF
--- a/bioio_tifffile/reader.py
+++ b/bioio_tifffile/reader.py
@@ -84,11 +84,14 @@ class Reader(reader.Reader):
         fs_kwargs: typing.Dict[str, typing.Any] = {},
         **kwargs: typing.Any,
     ):
-        if str(image).endswith(".ome.tiff"):
+        if ".ome.tif" in str(image):
             log.warning(
                 "The image ends with .ome.tiff, which might indicate an OME-TIFF "
                 "file format. You might want to install the "
                 "`bioio-ome-tiff` plug-in for improved metadata Processing."
+                "You can also use 'bioio.plugin_feasibility_report(image)' "
+                "method to check if a specific image can be handled by the "
+                "available plugins."
             )
 
         # Expand details of provided image

--- a/bioio_tifffile/reader.py
+++ b/bioio_tifffile/reader.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import logging
 import typing
 import warnings
 
@@ -21,6 +22,8 @@ from .utils import generate_ome_channel_id, generate_ome_image_id
 # "I" is used to mean a generic image sequence
 UNKNOWN_DIM_CHARS = ["Q", "I"]
 TIFF_IMAGE_DESCRIPTION_TAG_INDEX = 270
+
+log = logging.getLogger(__name__)
 
 ###############################################################################
 
@@ -81,6 +84,13 @@ class Reader(reader.Reader):
         fs_kwargs: typing.Dict[str, typing.Any] = {},
         **kwargs: typing.Any,
     ):
+        if str(image).endswith(".ome.tiff"):
+            log.warning(
+                "The image ends with .ome.tiff, which might indicate an OME-TIFF "
+                "file format. You might want to install the "
+                "`bioio-ome-tiff` plug-in for improved metadata Processing."
+            )
+
         # Expand details of provided image
         self._fs, self._path = io.pathlike_to_fs(
             image,


### PR DESCRIPTION
### Description 
The purpose of this PR was to resolve https://github.com/bioio-devs/bioio/issues/38 and unify the metadata that was being produced by bioio-tifffile and bioio-ome-tiff. In resolving this there were three vectors we pursued 

1. That bioio-tifffile is the default for .ome.tiff with both `bioio-tifffile` and `bioio-ome-tiff` installed. This is now resolved by https://github.com/bioio-devs/bioio/commit/3d1671314a65185dbe003a1943a4c9c4a0d69021
2. That the channel names do not match up
3. That the metadata is different for both images

This led to an exploration into the feasibility of accessing channel names, unfortunately all information about specific channels are locked within the ome-metadata block. This means that in order to align the channel names we need to go about some level of parsing of the metadata block. This would be the first instance of parsing the ome metadata in the tifffile reader and would blur the responsibilities of each reader.

From this there are two avenues.

1. Acknowledge that the readers are different and keep them separate. Include no handling of the ome format within tifffile and specify that it is not intended for ome-tiff. Informing users that they should use `bioio-ome-tiff`
Combine the readers into one super reader for all tiff files. This would mean pulling `bioio-tifffile` and `bioio-ome-tiff` in favor of `bioio-tiff`

2. There are benefits to both. If we keep the readers separate we keep our development simple and easy to iterate on, we allow the possibility of other formatted tiff files to be created in the future. On the otherhand combining them reduces possibility of user confusion, giving them more tools/ support.

I think I am of the opinion of combining the readers into one reader 

In regards to the third vector from the top of this post : That the metadata is different for both images. In tifffile we append the ome metadata whereas in `bioio-ome-tiff` we parse the metadata. This raises some additional issues, we use metadata as a catch all and with readers being moved to plugins the specifics of each readers metadata is undocumented. I do not have a good solution to this. 

What this PR does do as a half measure is provide a warning to any user trying to use the tifffile reader on an ome-tiff that better metadata handling will be present if they install `bioio-ome-tiff`. It does not resolve the separation of metadata which for the time being is "intended function" until we decide on our path.
