### PR TITLE
feature/support-zarr-3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,9 +34,8 @@ dependencies = [
   "fsspec>=2022.8.0",
   "imagecodecs>=2020.5.30",
   "numpy>=1.16",
-  "tifffile>=2023.7.10",
+  "tifffile[zarr]>=2023.7.10",
   "xarray>=0.16.1",
-  "zarr>=2.6,<3.0.0",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Description 

With the migration of the writers and tifffile now supporting zarr 3+ we can remove the pins!