### PR TITLE
update linting to 3.13; add noqa to pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,8 +44,6 @@ jobs:
   # Shared lint workflow from bioio-base
   lint:
     uses: bioio-devs/bioio-base/.github/workflows/shared_lint.yml@main
-    with:
-      lint_python_version: "3.11"
 
   # Check package performance
   benchmark:

--- a/bioio_tifffile/utils.py
+++ b/bioio_tifffile/utils.py
@@ -28,7 +28,7 @@ def generate_ome_channel_id(image_id: str, channel_id: typing.Union[str, int]) -
     """
     # Remove the prefix 'Image:' to get just the index
     image_index = image_id.replace("Image:", "")
-    return f"Channel:{image_index}:{channel_id}"
+    return f"Channel:{image_index}:{channel_id}"  # noqa: E231
 
 
 def generate_ome_image_id(image_id: typing.Union[str, int]) -> str:
@@ -47,4 +47,4 @@ def generate_ome_image_id(image_id: typing.Union[str, int]) -> str:
     ome_image_id: str
         The OME standard for image IDs.
     """
-    return f"Image:{image_id}"
+    return f"Image:{image_id}"  # noqa: E231


### PR DESCRIPTION
Remove the lint version specification parameter. Add noqa tags to allow passing lint for python 3.13
relevant to https://github.com/bioio-devs/bioio-base/issues/55
